### PR TITLE
Userdata update

### DIFF
--- a/tests/test_routes/test_user_post_then_get.py
+++ b/tests/test_routes/test_user_post_then_get.py
@@ -25,7 +25,7 @@ def test_create_new(dbsession, client, param, source, admin_source):
     dbsession.expire_all()
     assert response_upd.status_code == 200
     response_get = client.get("/user/0")
-    assert response_upd.json() == {'status': 'Successful', 'message': 'User patch succeeded'}
+    assert response_upd.json() == {'status': 'Success', 'message': 'User patch succeeded'}
     assert {"category": param.category.name, "param": param.name, "value": "admin_info"} in list(
         response_get.json()["items"]
     )
@@ -63,7 +63,7 @@ def test_delete(dbsession, client, param, admin_source):
     dbsession.expire_all()
     response_get = client.get("/user/0")
     assert response_upd.status_code == 200
-    assert response_upd.json() == {'status': 'Successful', 'message': 'User patch succeeded'}
+    assert response_upd.json() == {'status': 'Success', 'message': 'User patch succeeded'}
     assert response_get.status_code == 404
     dbsession.delete(info1)
     dbsession.commit()
@@ -94,7 +94,7 @@ def test_update(dbsession, client, param, admin_source):
     response_get = client.get("/user/0")
     assert response_upd.status_code == 200
     assert response_get.status_code == 200
-    assert response_upd.json() == {'status': 'Successful', 'message': 'User patch succeeded'}
+    assert response_upd.json() == {'status': 'Success', 'message': 'User patch succeeded'}
     assert {"category": param.category.name, "param": param.name, "value": "new"} in list(response_get.json()["items"])
     assert len(response_get.json()["items"]) == 1
     dbsession.delete(info1)
@@ -156,7 +156,7 @@ def test_update_not_changeable_with_scopes(dbsession, client, param, admin_sourc
     response_get = client.get("/user/0")
     assert response_get.status_code == 200
     assert response_upd.status_code == 200
-    assert response_upd.json() == {'status': 'Successful', 'message': 'User patch succeeded'}
+    assert response_upd.json() == {'status': 'Success', 'message': 'User patch succeeded'}
     assert {"category": param.category.name, "param": param.name, "value": "new"} in list(response_get.json()["items"])
     assert len(response_get.json()["items"]) == 1
     dbsession.delete(info1)
@@ -180,7 +180,7 @@ def test_create_new_no_category(dbsession, client, param, admin_source):
     response_get = client.get("/user/0")
     assert response_get.status_code == 200
     assert response_upd.status_code == 200
-    assert response_upd.json() == {'status': 'Successful', 'message': 'User patch succeeded'}
+    assert response_upd.json() == {'status': 'Success', 'message': 'User patch succeeded'}
     assert {"category": param.category.name, "param": param.name, "value": "new"} in list(response_get.json()["items"])
     assert len(response_get.json()["items"]) == 1
     info_new = (
@@ -211,7 +211,7 @@ def test_update_no_read_scope(dbsession, client, param, admin_source):
     response_get = client.get("/user/0")
     assert response_upd.status_code == 200
     assert response_get.status_code == 200
-    assert response_upd.json() == {'status': 'Successful', 'message': 'User patch succeeded'}
+    assert response_upd.json() == {'status': 'Success', 'message': 'User patch succeeded'}
     assert response_get.json() == {"items": []}
     assert info1.value == "new"
     dbsession.delete(info1)
@@ -244,7 +244,7 @@ def test_update_from_user_source(dbsession, client, param, source):
     dbsession.expire_all()
     response_get = client.get("/user/0")
     assert response_upd.status_code == 200
-    assert response_upd.json() == {'status': 'Successful', 'message': 'User patch succeeded'}
+    assert response_upd.json() == {'status': 'Success', 'message': 'User patch succeeded'}
     assert response_get.status_code == 200
     assert {"category": param.category.name, "param": param.name, "value": "new_user_info"} in list(
         response_get.json()["items"]

--- a/tests/test_routes/test_user_post_then_get.py
+++ b/tests/test_routes/test_user_post_then_get.py
@@ -25,7 +25,7 @@ def test_create_new(dbsession, client, param, source, admin_source):
     dbsession.expire_all()
     assert response_upd.status_code == 200
     response_get = client.get("/user/0")
-    assert response_get.json() == response_upd.json()
+    assert response_upd.json() == {'status': 'Successful', 'message': 'User patch succeeded'}
     assert {"category": param.category.name, "param": param.name, "value": "admin_info"} in list(
         response_get.json()["items"]
     )
@@ -63,8 +63,8 @@ def test_delete(dbsession, client, param, admin_source):
     dbsession.expire_all()
     response_get = client.get("/user/0")
     assert response_upd.status_code == 200
-    assert response_get.json() == response_upd.json()
-    assert response_get.json() == {"items": []}
+    assert response_upd.json() == {'status': 'Successful', 'message': 'User patch succeeded'}
+    assert response_get.status_code == 404
     dbsession.delete(info1)
     dbsession.commit()
 
@@ -93,7 +93,8 @@ def test_update(dbsession, client, param, admin_source):
     dbsession.expire_all()
     response_get = client.get("/user/0")
     assert response_upd.status_code == 200
-    assert response_get.json() == response_upd.json()
+    assert response_get.status_code == 200
+    assert response_upd.json() == {'status': 'Successful', 'message': 'User patch succeeded'}
     assert {"category": param.category.name, "param": param.name, "value": "new"} in list(response_get.json()["items"])
     assert len(response_get.json()["items"]) == 1
     dbsession.delete(info1)
@@ -153,8 +154,9 @@ def test_update_not_changeable_with_scopes(dbsession, client, param, admin_sourc
     )
     dbsession.expire_all()
     response_get = client.get("/user/0")
+    assert response_get.status_code == 200
     assert response_upd.status_code == 200
-    assert response_get.json() == response_upd.json()
+    assert response_upd.json() == {'status': 'Successful', 'message': 'User patch succeeded'}
     assert {"category": param.category.name, "param": param.name, "value": "new"} in list(response_get.json()["items"])
     assert len(response_get.json()["items"]) == 1
     dbsession.delete(info1)
@@ -169,15 +171,16 @@ def test_create_new_no_category(dbsession, client, param, admin_source):
     param.category.read_scope = "test.cat_read.first"
     dbsession.commit()
     response_old = client.get("/user/0")
-    assert response_old.json() == {"items": []}
+    assert response_old.status_code == 404
     response_upd = client.post(
         f"/user/0",
         json={"source": "admin", "items": [{"category": param.category.name, "param": param.name, "value": "new"}]},
     )
     dbsession.expire_all()
     response_get = client.get("/user/0")
+    assert response_get.status_code == 200
     assert response_upd.status_code == 200
-    assert response_get.json() == response_upd.json()
+    assert response_upd.json() == {'status': 'Successful', 'message': 'User patch succeeded'}
     assert {"category": param.category.name, "param": param.name, "value": "new"} in list(response_get.json()["items"])
     assert len(response_get.json()["items"]) == 1
     info_new = (
@@ -207,7 +210,8 @@ def test_update_no_read_scope(dbsession, client, param, admin_source):
     dbsession.expire_all()
     response_get = client.get("/user/0")
     assert response_upd.status_code == 200
-    assert response_get.json() == response_upd.json()
+    assert response_get.status_code == 200
+    assert response_upd.json() == {'status': 'Successful', 'message': 'User patch succeeded'}
     assert response_get.json() == {"items": []}
     assert info1.value == "new"
     dbsession.delete(info1)
@@ -240,7 +244,8 @@ def test_update_from_user_source(dbsession, client, param, source):
     dbsession.expire_all()
     response_get = client.get("/user/0")
     assert response_upd.status_code == 200
-    assert response_get.json() == response_upd.json()
+    assert response_upd.json() == {'status': 'Successful', 'message': 'User patch succeeded'}
+    assert response_get.status_code == 200
     assert {"category": param.category.name, "param": param.name, "value": "new_user_info"} in list(
         response_get.json()["items"]
     )
@@ -277,7 +282,7 @@ def test_update_from_user_source_not_changeable(dbsession, client, param, source
     dbsession.expire_all()
     response_get = client.get("/user/0")
     assert response_upd.status_code == 403
-    assert response_get.json() != response_upd.json()
+    assert response_get.status_code == 200
     assert {"category": param.category.name, "param": param.name, "value": "user_info"} in list(
         response_old.json()["items"]
     )

--- a/userdata_api/routes/user.py
+++ b/userdata_api/routes/user.py
@@ -63,4 +63,4 @@ async def update_user(
     :return:
     """
     await patch(new_info, id, user)
-    return StatusResponseModel(status='Successful', message='User patch succeeded')
+    return StatusResponseModel(status='Success', message='User patch succeeded')

--- a/userdata_api/routes/user.py
+++ b/userdata_api/routes/user.py
@@ -6,6 +6,7 @@ from fastapi import APIRouter, Depends
 from userdata_api.schemas.user import UserInfoGet, UserInfoUpdate
 from userdata_api.utils.user import get_user_info as get
 from userdata_api.utils.user import patch_user_info as patch
+from userdata_api.schemas.response_model import StatusResponseModel
 
 
 user = APIRouter(prefix="/user", tags=["User"])
@@ -31,12 +32,12 @@ async def get_user_info(
     return UserInfoGet.model_validate(await get(id, user))
 
 
-@user.post("/{id}", response_model=UserInfoGet)
+@user.post("/{id}", response_model=StatusResponseModel)
 async def update_user(
     new_info: UserInfoUpdate,
     id: int,
     user: dict[str, Any] = Depends(UnionAuth(scopes=[], allow_none=False, auto_error=True)),
-) -> UserInfoGet:
+) -> StatusResponseModel:
     """
     Обновить информацию о пользователе.
     Объект - пользователь, информацию которого обновляют
@@ -61,4 +62,5 @@ async def update_user(
     :param user:
     :return:
     """
-    return UserInfoGet.model_validate(await patch(new_info, id, user))
+    await patch(new_info, id, user)
+    return StatusResponseModel(status='Successful', message='User patch succeeded')

--- a/userdata_api/routes/user.py
+++ b/userdata_api/routes/user.py
@@ -3,10 +3,10 @@ from typing import Any
 from auth_lib.fastapi import UnionAuth
 from fastapi import APIRouter, Depends
 
+from userdata_api.schemas.response_model import StatusResponseModel
 from userdata_api.schemas.user import UserInfoGet, UserInfoUpdate
 from userdata_api.utils.user import get_user_info as get
 from userdata_api.utils.user import patch_user_info as patch
-from userdata_api.schemas.response_model import StatusResponseModel
 
 
 user = APIRouter(prefix="/user", tags=["User"])

--- a/userdata_api/utils/user.py
+++ b/userdata_api/utils/user.py
@@ -10,7 +10,7 @@ from userdata_api.schemas.user import UserInfoGet, UserInfoUpdate
 
 async def patch_user_info(
     new: UserInfoUpdate, user_id: int, user: dict[str, int | list[dict[str, str | int]]]
-) -> UserInfoGet:
+) -> None:
     """
     Обновить информацию о пользователе в соотетствии с переданным токеном.
 
@@ -86,10 +86,10 @@ async def patch_user_info(
             info.value = item.value
             db.session.commit()
             continue
-        info.is_deleted = True
-        db.session.flush()
-        continue
-    return await get_user_info(user_id, user)
+        if item.value is None:
+            info.is_deleted = True
+            db.session.flush()
+            continue
 
 
 async def get_user_info(user_id: int, user: dict[str, int | list[dict[str, str | int]]]) -> UserInfoGet:
@@ -105,6 +105,8 @@ async def get_user_info(user_id: int, user: dict[str, int | list[dict[str, str |
     :return: Список словарей содержащих категорию, параметр категории и значение этого параметра у польщователя
     """
     infos: list[Info] = Info.query(session=db.session).filter(Info.owner_id == user_id).all()
+    if not infos:
+        raise ObjectNotFound(Info, user_id)
     scope_names = [scope["name"] for scope in user["session_scopes"]]
     param_dict: dict[Param, list[Info] | Info | None] = {}
     for info in infos:

--- a/userdata_api/utils/user.py
+++ b/userdata_api/utils/user.py
@@ -82,7 +82,7 @@ async def patch_user_info(new: UserInfoUpdate, user_id: int, user: dict[str, int
                 db.session.rollback()
                 raise Forbidden(f"Param {param.name=} change requires 'userdata.info.update' scope")
             info.value = item.value
-            db.session.commit()
+            db.session.flush()
             continue
         if item.value is None:
             info.is_deleted = True

--- a/userdata_api/utils/user.py
+++ b/userdata_api/utils/user.py
@@ -8,9 +8,7 @@ from userdata_api.models.db import Category, Info, Param, Source, ViewType
 from userdata_api.schemas.user import UserInfoGet, UserInfoUpdate
 
 
-async def patch_user_info(
-    new: UserInfoUpdate, user_id: int, user: dict[str, int | list[dict[str, str | int]]]
-) -> None:
+async def patch_user_info(new: UserInfoUpdate, user_id: int, user: dict[str, int | list[dict[str, str | int]]]) -> None:
     """
     Обновить информацию о пользователе в соотетствии с переданным токеном.
 


### PR DESCRIPTION
## Изменения
1. Добавлена ошибка 404 при получении информации о не существующем в базе данных репозитория [`userdata`](https://github.com/profcomff/userdata-api) пользователе.
2. Теперь при успешном обновлении данных о пользователе возвращается другая модель данных.
3. Переделаны старые тесты под данные изменения.

## Реализации
1. Ошибка 404 прокидывается при отсутствии пользователя с заданным при запросе id.
2. При посылании post-запроса`/user/{id}` возвращается модель `StatusResponseModel`.

## Детали
1. Раньше ручка post-запроса `/user/{id}` своим результатом работы имела возвращаемое значение ручки get-запроса `/user/{id}`. Теперь просто возвращается успешно ли отработала ручка post-запроса или нет.
2. Необходимость изменения тестов вызвана тем, что, изменена возвращаемая модель данных ручки post-запроса.
3. Изменение результата работы ручки post-запроса было необходимо ввиду того, что при удалении информации о пользователе из базы данных, возвращалась ошибка 404. Ответ приходил с ошибкой, так как сразу после удаления в возврат функции уходил результат работы ручки get-запроса, в которой не удавалось найти удаленную ранее запись в базе.

## Check-List
- [x] Вы проверили свой код перед отправкой запроса?
- [x] Вы написали тесты к реализованным функциям?
- [x] Вы не забыли применить black и isort?
